### PR TITLE
Remove hardcoded endpoints

### DIFF
--- a/widget.html
+++ b/widget.html
@@ -34,15 +34,17 @@
       </div>
     </div>
   </div>
+  <!-- Define ListingPilotConfig before loading the widget so it can read the
+       webhook URL at runtime. Example:
+       &lt;script&gt;window.ListingPilotConfig = { webhookUrl: "https://example.com/chat" };&lt;/script&gt; -->
   <script src="widget.js"></script>
   <script>
     RealtorWidget.init({
       containerId: "realtor-widget-container",
-      chatEndpoint: "http://3.143.23.149:5001/chat",
-      historyEndpoint: "http://3.143.23.149:5001/chat/history",
-      branding: { 
+      // webhookUrl is read from window.ListingPilotConfig; no endpoints here.
+      branding: {
         logo: "https://i.ibb.co/fV7Z2NVT/Logo-removebg-modified.png",
-        themeColor: "#2c3e50" 
+        themeColor: "#2c3e50"
       }
     });
   </script>


### PR DESCRIPTION
## Summary
- read webhook URL from `window.ListingPilotConfig.webhookUrl`
- check webhook configuration at startup and when sending messages
- document runtime config in HTML example

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684a0b52c9008332bcf6b71e9b50d47f