### PR TITLE
Add configuration template and update widget example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/config.js
+

--- a/config.example.js
+++ b/config.example.js
@@ -1,0 +1,16 @@
+/*
+ * Configuration template for ListingPilot chat widget.
+ * Copy this file to `config.js` and replace the placeholder values
+ * with your real webhook URL and any branding options. The widget
+ * reads these values at runtime so URLs don't need to be hardcoded
+ * in your build.
+ */
+window.ListingPilotConfig = {
+  // URL of your n8n webhook that processes chat messages.
+  webhookUrl: "https://YOUR_N8N_INSTANCE_DOMAIN/webhook/chat",
+
+  // Optional settings for branding the widget interface.
+  // agentName: "Your Name",
+  // primaryColor: "#0A1F44",
+  // logoUrl: "https://example.com/logo.png"
+};

--- a/widget.html
+++ b/widget.html
@@ -34,17 +34,30 @@
       </div>
     </div>
   </div>
+  <!-- Runtime configuration allows the webhook URL to be changed without
+       modifying widget.js -->
+  <script src="config.js"></script>
+  <!-- Main widget script -->
   <script src="widget.js"></script>
   <script>
+    // Initialize using values from ListingPilotConfig defined in config.js
     RealtorWidget.init({
       containerId: "realtor-widget-container",
-      chatEndpoint: "http://3.143.23.149:5001/chat",
-      historyEndpoint: "http://3.143.23.149:5001/chat/history",
-      branding: { 
-        logo: "https://i.ibb.co/fV7Z2NVT/Logo-removebg-modified.png",
-        themeColor: "#2c3e50" 
+      chatEndpoint: window.ListingPilotConfig.webhookUrl,
+      // Optionally use branding fields from ListingPilotConfig
+      branding: {
+        logo: window.ListingPilotConfig.logoUrl || "https://i.ibb.co/fV7Z2NVT/Logo-removebg-modified.png",
+        themeColor: window.ListingPilotConfig.primaryColor || "#2c3e50",
+        agentName: window.ListingPilotConfig.agentName
       }
     });
   </script>
+  <!-- Example when loading widget.js from a CDN:
+  <script>
+    window.ListingPilotConfig = { webhookUrl: "https://YOUR_DOMAIN/webhook/chat" };
+  </script>
+  <script src="https://cdn.example.com/listingpilot-widget.js"></script>
+  -->
+  <!-- Ensure your webhook endpoint allows CORS requests from the page hosting the widget -->
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add runtime `config.example.js` for user settings
- ignore `config.js` in git
- load `config.js` from `widget.html` and demonstrate inline config snippet

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684a0bb231608332b68d3f8151a794bd