### PR TITLE
Add testing mode for conversation IDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ You need an HTTP endpoint that implements your chat logic (for example using [n8
 - `historyEndpoint` – optional endpoint for past conversation (if supported)
 - `agentName` – displayed in the header
 - `primaryColor` and `accentColor` – override theme colors
+- `testingMode` – if `true`, a new conversation ID is created on each page reload
 
 ## CORS Requirements
 

--- a/config.example.js
+++ b/config.example.js
@@ -9,5 +9,6 @@ window.ListingPilotConfig = {
   agentName: "Realtor Assistant",
   primaryColor: "#2c3e50",
   accentColor: "#16a085",
-  historyEndpoint: "https://example.com/history" // optional
+  historyEndpoint: "https://example.com/history", // optional
+  testingMode: false // set to true to generate a new conversation ID on each reload
 };

--- a/widget.js
+++ b/widget.js
@@ -33,6 +33,14 @@ const RealtorWidget = (() => {
   // conversational flows.
   function getConversationId() {
     const key = 'ListingPilotConversationId';
+    const testingMode = window?.ListingPilotConfig?.testingMode;
+
+    // In testing mode we skip persistence so a new ID is created on each reload
+    if (testingMode) {
+      if (!memoryConversationId) memoryConversationId = generateUUID();
+      return memoryConversationId;
+    }
+
     try {
       if (window.localStorage) {
         let id = localStorage.getItem(key);


### PR DESCRIPTION
## Summary
- allow configuring a `testingMode` flag
- skip localStorage persistence when testing mode is enabled
- document the new option in README and config example

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684f3e5069d483329281cb8774fd5de7